### PR TITLE
Deployment URLs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,8 @@ runs:
     REPOSITORY_NAME: ${{ inputs.repository_name }}
     BRANCH_NAME: ${{ inputs.branch_name }}
     INITIATOR: ${{ inputs.initiator }}
-    DEPLOYMENT_URL: ${{ inputs.deployment_url }}
+    DEPLOYMENT_URL: ${{ vars[format('{0}_DEPLOYMENT_URL', inputs.branch_name)] }}
     TEAMS_WEBHOOK_URL: ${{ inputs.teams_webhook_url }}
     MESSAGE: ${{ inputs.message }}
     PROGRESS_URL: ${{ inputs.progress_url }}
+    VARIABLE_SETUP_URL: https://github.com/${{ github.repository_owner }}/${{ inputs.repository_name }}/settings/variables/actions/new

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     REPOSITORY_NAME: ${{ inputs.repository_name }}
     BRANCH_NAME: ${{ inputs.branch_name }}
     INITIATOR: ${{ inputs.initiator }}
-    DEPLOYMENT_URL: ${{ vars[format('{0}_DEPLOYMENT_URL', inputs.branch_name)] }}
+    DEPLOYMENT_URL: ${{ vars[format('{0}_DEPLOYMENT_URL', inputs.branch_name)] || '' }}
     TEAMS_WEBHOOK_URL: ${{ inputs.teams_webhook_url }}
     MESSAGE: ${{ inputs.message }}
     PROGRESS_URL: ${{ inputs.progress_url }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,12 +27,11 @@ json_payload=$(cat << EOF
                             {
                                 "title": "Branch:",
                                 "value": "${BRANCH_NAME}"
-                            }
-                            $([ -n "${DEPLOYMENT_URL}" ] && echo ',
+                            },
                             {
                                 "title": "Deployment URL:",
-                                "value": "'${DEPLOYMENT_URL}'"
-                            }')
+                                "value": $([ -n "${DEPLOYMENT_URL}" ] && echo '"'${DEPLOYMENT_URL}'"' || echo '"Not set. Set the repository secret [BRANCH_NAME]_DEPLOYMENT_URL to enable."')
+                            }
                         ]
                     }
                 ],
@@ -47,6 +46,11 @@ json_payload=$(cat << EOF
                         "type": "Action.OpenUrl",
                         "title": "View Site",
                         "url": "'${DEPLOYMENT_URL}'"
+                    }' || echo ',
+                    {
+                        "type": "Action.OpenUrl",
+                        "title": "Setup Deployment URL",
+                        "url": "'${VARIABLE_SETUP_URL}'"
                     }')
                 ]
             }


### PR DESCRIPTION
# Changes Summary

- This changes the "View Site" button on the Teams card to pull from a [Github repository variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables).
- Based on the branch name, the Teams card looks for a specific variable, based on the branch name. Some examples would be: `DEVELOP_DEPLOYMENT_URL`, `STAGE_DEPLOYMENT_URL` or `MAIN_DEPLOYMENT_URL` (I know this last one seems strange, because we usually use the language 'live' when talking about deployments, rather than 'main').
- If this variable isn't set, then instead the card will contain a message reflecting this, and a link to where the variable can be set.

This feels fragile and stupid to me, but I couldn't think of a better way. I'd appreciate any other ideas.